### PR TITLE
feat: add system name filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,12 @@ import (
 )
 
 func main() {
+
+	var timerNames []string
+	if len(os.Args) > 1 {
+		timerNames = os.Args[1:]
+	}
+
 	conn, err := systemd.NewConn()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -17,7 +23,7 @@ func main() {
 
 	client := systemd.NewClient(conn)
 
-	timers, err := client.ListTimers()
+	timers, err := client.ListTimers(timerNames)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/systemd/daemon_test.go
+++ b/systemd/daemon_test.go
@@ -1,0 +1,15 @@
+package systemd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMatchTimer(t *testing.T) {
+	assert.True(t, matchTimer("system-test-01", []string{"system-test-*"}))
+	assert.True(t, matchTimer("system-test-01", []string{"system-*-01"}))
+	assert.True(t, matchTimer("system-test-01", []string{"system-*-01*", "system-test-02"}))
+	assert.False(t, matchTimer("system-test-01", []string{"system-test-1"}))
+	assert.True(t, matchTimer("system-test-01", []string{"system-test-1", "system-test-01"}))
+	assert.False(t, matchTimer("", []string{"system-test-1", "system-test-01"}))
+}


### PR DESCRIPTION
for example:
systemd-timers 'systemd-*'
systemd-timers systemd-readahead-done systemd-tmpfiles-clean

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/5196641/218269010-ef01f8cf-8d2b-4889-8481-4824e249bb33.png">
